### PR TITLE
Add JavaZonedDateTimeAdapter (#21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Apollo Kotlin Adapters contains adapters for common date and big decimal classes
 | `JavaLocalDateTimeAdapter`    | apollo-adapters-core             | `java.time.LocalDateTime`                   |
 | `JavaLocalTimeAdapter`        | apollo-adapters-core             | `java.time.LocalTime`                       |
 | `JavaOffsetDateTimeAdapter`   | apollo-adapters-core             | `java.time.OffsetDateTime`                  |
+| `JavaZonedDateTimeAdapter`    | apollo-adapters-core             | `java.time.ZonedDateTime`                   |
 | `DateAdapter`                 | apollo-adapters-core             | `java.util.Date`                            |
 | `UnitAdapter`                 | apollo-adapters-core             | `kotlin.Unit`                               |
 | `KotlinxInstantAdapter`       | apollo-adapters-kotlinx-datetime | `kotlinx.datetime.Instant`                  |

--- a/apollo-adapters-core/api/apollo-adapters-core.api
+++ b/apollo-adapters-core/api/apollo-adapters-core.api
@@ -58,6 +58,14 @@ public final class com/apollographql/adapter/core/JavaOffsetDateTimeAdapter : co
 	public fun toJson (Lcom/apollographql/apollo/api/json/JsonWriter;Lcom/apollographql/apollo/api/CustomScalarAdapters;Ljava/time/OffsetDateTime;)V
 }
 
+public final class com/apollographql/adapter/core/JavaZonedDateTimeAdapter : com/apollographql/apollo/api/Adapter {
+	public static final field INSTANCE Lcom/apollographql/adapter/core/JavaZonedDateTimeAdapter;
+	public synthetic fun fromJson (Lcom/apollographql/apollo/api/json/JsonReader;Lcom/apollographql/apollo/api/CustomScalarAdapters;)Ljava/lang/Object;
+	public fun fromJson (Lcom/apollographql/apollo/api/json/JsonReader;Lcom/apollographql/apollo/api/CustomScalarAdapters;)Ljava/time/ZonedDateTime;
+	public synthetic fun toJson (Lcom/apollographql/apollo/api/json/JsonWriter;Lcom/apollographql/apollo/api/CustomScalarAdapters;Ljava/lang/Object;)V
+	public fun toJson (Lcom/apollographql/apollo/api/json/JsonWriter;Lcom/apollographql/apollo/api/CustomScalarAdapters;Ljava/time/ZonedDateTime;)V
+}
+
 public final class com/apollographql/adapter/core/UnitAdapter : com/apollographql/apollo/api/Adapter {
 	public static final field INSTANCE Lcom/apollographql/adapter/core/UnitAdapter;
 	public synthetic fun fromJson (Lcom/apollographql/apollo/api/json/JsonReader;Lcom/apollographql/apollo/api/CustomScalarAdapters;)Ljava/lang/Object;

--- a/apollo-adapters-core/src/jvmMain/kotlin/com/apollographql/adapter/core/JavaTimeAdapters.kt
+++ b/apollo-adapters-core/src/jvmMain/kotlin/com/apollographql/adapter/core/JavaTimeAdapters.kt
@@ -9,6 +9,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.OffsetDateTime
+import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
 
@@ -88,6 +89,25 @@ object JavaOffsetDateTimeAdapter : Adapter<OffsetDateTime> {
 }
 
 /**
+ * An [Adapter] that converts a date and time to/from [java.time.ZonedDateTime]
+ *
+ * Examples:
+ * - "2010-06-01T22:19:44.475Z"
+ * - "2010-06-01T23:19:44.475+01:00"
+ * - "2010-06-01T23:19:44.475+02:00[Europe/Prague]"
+ *
+ */
+object JavaZonedDateTimeAdapter : Adapter<ZonedDateTime> {
+  override fun fromJson(reader: JsonReader, customScalarAdapters: CustomScalarAdapters): ZonedDateTime {
+    return ZonedDateTime.parse(reader.nextString()!!)
+  }
+
+  override fun toJson(writer: JsonWriter, customScalarAdapters: CustomScalarAdapters, value: ZonedDateTime) {
+    writer.value(value.format(DateTimeFormatter.ISO_ZONED_DATE_TIME))
+  }
+}
+
+/**
  * An [Adapter] that converts a time to/from [java.time.LocalTime]
  *
  * Examples:
@@ -97,7 +117,7 @@ object JavaOffsetDateTimeAdapter : Adapter<OffsetDateTime> {
  */
 object JavaLocalTimeAdapter : Adapter<LocalTime> {
   override fun fromJson(reader: JsonReader, customScalarAdapters: CustomScalarAdapters): LocalTime {
-    return LocalTime.parse(reader.nextString())
+    return LocalTime.parse(reader.nextString()!!)
   }
 
   override fun toJson(writer: JsonWriter, customScalarAdapters: CustomScalarAdapters, value: LocalTime) {

--- a/apollo-adapters-core/src/jvmTest/kotlin/JavaTimeAdaptersTest.kt
+++ b/apollo-adapters-core/src/jvmTest/kotlin/JavaTimeAdaptersTest.kt
@@ -24,6 +24,18 @@ class JavaTimeAdaptersTest {
   }
 
   @Test
+  fun date() {
+    var date = DateAdapter.fromJson("2010-06-01T22:19:44.475Z")
+    assertEquals(1275430784475, date.time)
+    assertEquals("2010-06-01T22:19:44.475Z", DateAdapter.toJson(date))
+
+    date = DateAdapter.fromJson("2010-06-01T23:19:44.475+01:00")
+    assertEquals(1275430784475, date.time)
+    // Time zone is lost
+    assertEquals("2010-06-01T22:19:44.475Z", DateAdapter.toJson(date))
+  }
+
+  @Test
   fun instant() {
     var instant = JavaInstantAdapter.fromJson("2010-06-01T22:19:44.475Z")
     assertEquals(1275430784475, instant.toEpochMilli())
@@ -33,6 +45,20 @@ class JavaTimeAdaptersTest {
     assertEquals(1275430784475, instant.toEpochMilli())
     // Time zone is lost
     assertEquals("2010-06-01T22:19:44.475Z", JavaInstantAdapter.toJson(instant))
+  }
+
+  @Test
+  fun localDate() {
+    val localDate = JavaLocalDateAdapter.fromJson("2010-06-01")
+    assertEquals(1275430784, localDate.atTime(LocalTime.parse("22:19:44.475")).toEpochSecond(ZoneOffset.UTC))
+    assertEquals("2010-06-01", JavaLocalDateAdapter.toJson(localDate))
+  }
+
+  @Test
+  fun localDateTime() {
+    val localDateTime = JavaLocalDateTimeAdapter.fromJson("2010-06-01T22:19:44.475")
+    assertEquals(1275430784, localDateTime.toEpochSecond(ZoneOffset.UTC))
+    assertEquals("2010-06-01T22:19:44.475", JavaLocalDateTimeAdapter.toJson(localDateTime))
   }
 
   @Test
@@ -48,29 +74,20 @@ class JavaTimeAdaptersTest {
   }
 
   @Test
-  fun date() {
-    var date = DateAdapter.fromJson("2010-06-01T22:19:44.475Z")
-    assertEquals(1275430784475, date.time)
-    assertEquals("2010-06-01T22:19:44.475Z", DateAdapter.toJson(date))
+  fun zonedDateTimeDateTime() {
+    var zonedDateTimeDateTime = JavaZonedDateTimeAdapter.fromJson("2010-06-01T23:19:44.475+01:00[Etc/GMT-1]")
+    assertEquals(1275430784475, zonedDateTimeDateTime.toInstant().toEpochMilli())
+    // ZonedDateTime is retained
+    assertEquals("2010-06-01T23:19:44.475+01:00[Etc/GMT-1]", JavaZonedDateTimeAdapter.toJson(zonedDateTimeDateTime))
 
-    date = DateAdapter.fromJson("2010-06-01T23:19:44.475+01:00")
-    assertEquals(1275430784475, date.time)
-    // Time zone is lost
-    assertEquals("2010-06-01T22:19:44.475Z", DateAdapter.toJson(date))
-  }
+    zonedDateTimeDateTime = JavaZonedDateTimeAdapter.fromJson("2010-06-01T23:19:44.475+01:00")
+    assertEquals(1275430784475, zonedDateTimeDateTime.toInstant().toEpochMilli())
+    // Offset is retained
+    assertEquals("2010-06-01T23:19:44.475+01:00", JavaZonedDateTimeAdapter.toJson(zonedDateTimeDateTime))
 
-  @Test
-  fun localDateTime() {
-    val localDateTime = JavaLocalDateTimeAdapter.fromJson("2010-06-01T22:19:44.475")
-    assertEquals(1275430784, localDateTime.toEpochSecond(ZoneOffset.UTC))
-    assertEquals("2010-06-01T22:19:44.475", JavaLocalDateTimeAdapter.toJson(localDateTime))
-  }
-
-  @Test
-  fun localDate() {
-    val localDate = JavaLocalDateAdapter.fromJson("2010-06-01")
-    assertEquals(1275430784, localDate.atTime(LocalTime.parse("22:19:44.475")).toEpochSecond(ZoneOffset.UTC))
-    assertEquals("2010-06-01", JavaLocalDateAdapter.toJson(localDate))
+    zonedDateTimeDateTime = JavaZonedDateTimeAdapter.fromJson("2010-06-01T22:19:44.475Z")
+    assertEquals(1275430784475, zonedDateTimeDateTime.toInstant().toEpochMilli())
+    assertEquals("2010-06-01T22:19:44.475Z", JavaZonedDateTimeAdapter.toJson(zonedDateTimeDateTime))
   }
 
   @Test


### PR DESCRIPTION
#### Description

This pull request introduces a new adapter, `JavaZonedDateTimeAdapter`, to handle serialization and deserialization of `java.time.ZonedDateTime` objects. This addition enhances the Apollo Adapters Core library by providing support for `ZonedDateTime`, ensuring proper conversion to and from JSON format.

#### Changes Made

1. **New Adapter Class:**
   - Added `JavaZonedDateTimeAdapter` in `JavaTimeAdapters.kt`.
   - Implemented the `fromJson` method to parse a `ZonedDateTime` object from a JSON string using `ZonedDateTime.parse`.
   - Implemented the `toJson` method to convert a `ZonedDateTime` object to a JSON string formatted according to `DateTimeFormatter.ISO_ZONED_DATE_TIME`.

2. **API Documentation Update:**
   - Updated the API file `apollo-adapters-core.api` to include the new `JavaZonedDateTimeAdapter` class, along with its methods for JSON serialization (`toJson`) and deserialization (`fromJson`).

3. **Test Cases:**
   - Added new test cases in `JavaTimeAdaptersTest.kt`:
     - Verified parsing of `ZonedDateTime` strings with different formats, including standard UTC (`Z`) and various offsets.
     - Confirmed that `ZonedDateTime` objects are serialized back to their correct string representations.

4. **Minor Adjustments:**
   - Ensured non-null assertions (`!!`) when parsing date strings in existing adapters to avoid possible NPE warning.
   - Rearranged existing test methods to accommodate new test cases and maintain logical flow.

#### Rationale

Adding support for `ZonedDateTime` is critical for handling date-time data that includes specific time zones, which is often required in distributed systems and APIs that interact across different geographical regions. This enhancement will allow developers to work with date-time values more accurately, taking into account time zone differences.

#### Testing

- All new and existing tests pass successfully.
- Tests cover a variety of `ZonedDateTime` formats to ensure robust parsing and formatting capabilities.

#### Impact

This change is backward-compatible and introduces additional functionality without affecting existing behavior. Developers using the Apollo Adapters Core can now seamlessly work with `ZonedDateTime` types.

Please review the proposed changes and provide feedback. If there are any other considerations or improvements, feel free to suggest them. Thank you!

Closes #21
